### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "delete"
   ],
   "dependencies": {
-    "@strapi/design-system": "^1.8.2",
+    "@strapi/design-system": "^1.13.0",
     "@strapi/helper-plugin": "^4.11.5",
     "@strapi/icons": "^1.8.2",
     "@strapi/utils": "^4.11.5",


### PR DESCRIPTION
### What does it do?

Adds compatibility with Strapi 4.14.5 & 4.15.0 (those were tested).

### Why is it needed?

`npm install` fails otherwise, unless you use `--force` or `--legacy-peer-deps`, which can produce incredibly weird and hard to fix bugs.

### How to test it?

1. Update to Strapi 4.14.5
2. Install the forked repository

It will install, but it will complain at runtime about a missing `./dist` folder, but that's expected.

### Related issue(s)/PR(s)

n/a
